### PR TITLE
Create composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,23 @@
+{
+  "name": "strangerstudios/pmpro-mailchimp",
+  "description": "Paid Memberships Pro - MailChimp Add On - Sync WordPress Users and PMPro Members with MailChimp lists.",
+  "homepage": "https://github.com/strangerstudios/pmpro-mailchimp",
+  "version": "2.0.2",
+  "license": "GPL-2.0",
+  "authors": [
+    {
+      "name": "Jason Coleman",
+      "homepage": "https://github.com/strangerstudios"
+    }
+  ],
+  "support": {
+    "issues": "https://github.com/strangerstudios/pmpro-mailchimp/issues"
+  },
+  "type": "wordpress-plugin",
+  "require": {
+    "php": ">=5.3.2",
+    "composer/installers": "~1.0.12",
+    "johnpbloch/wordpress": ">=3.5",
+    "wpackagist-plugin/paid-memberships-pro": ">=1.8.8.3"
+  }
+}


### PR DESCRIPTION
Add composer support for developers using PHP Package management with WordPress.
